### PR TITLE
Remove CI badge for concourse on wings.pivotal.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please file Pull Requests and / or Issues for missing CI platforms :smile:
 | [CircleCI](https://circleci.com/) | [Yes](.circleci) :heavy_check_mark: | [![CircleCI](https://circleci.com/gh/kind-ci/examples.svg?style=svg)](https://circleci.com/gh/kind-ci/examples) |
 | [Travis CI](https://travis-ci.com/) | [Yes](.travis.yml) :heavy_check_mark: | [![Travis CI](https://travis-ci.com/kind-ci/examples.svg?branch=master)](https://travis-ci.com/kind-ci/examples/) |
 | [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) | [Yes](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kind) :heavy_check_mark: | [![Prow](https://prow.k8s.io/badge.svg?jobs=ci-kind-build)](https://prow.k8s.io/?job=ci-kind-build) |
-| [Concourse](https://concourse-ci.org/) | [Yes](concourse.md) :heavy_check_mark: | [![Concourse k8s](https://hush-house.pivotal.io/api/v1/teams/k8s-c10s/pipelines/kind/badge)](https://hush-house.pivotal.io/teams/k8s-c10s/pipelines/kind?group=all) [![Concourse BOSH](https://wings.pivotal.io/api/v1/teams/k8s-c10s/pipelines/kind/badge)](https://wings.pivotal.io/teams/k8s-c10s/pipelines/kind?group=all) |
+| [Concourse](https://concourse-ci.org/) | [Yes](concourse.md) :heavy_check_mark: | [![Concourse k8s](https://hush-house.pivotal.io/api/v1/teams/k8s-c10s/pipelines/kind/badge)](https://hush-house.pivotal.io/teams/k8s-c10s/pipelines/kind?group=all) |
 | [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | [Yes](azure-pipelines.yml) :heavy_check_mark: | None |
 | [Drone](https://drone.io/) | [Yes](./drone) :heavy_check_mark: | None |
 | [Gitlab](https://about.gitlab.com/product/continuous-integration/) | [Yes](.gitlab-ci.yml) :heavy_check_mark: | None |

--- a/concourse.md
+++ b/concourse.md
@@ -55,5 +55,5 @@ resources:
 [kind]: //kind.sigs.k8s.io/
 [concourse]: //concourse-ci.org/
 [kind-on-c]: //github.com/pivotal-k8s/kind-on-c
-[ci]: //wings.pivotal.io/teams/k8s-c10s/pipelines/kind
+[ci]: //hush-house.pivotal.io/teams/k8s-c10s/pipelines/kind
 [ci-src]: //github.com/pivotal-k8s/kind-on-c/tree/master/ci/


### PR DESCRIPTION
We had the same pipeline running on wings (concourse deployed via BOSH
on VMs) and hush-house (conourse deployed as a helm chart onto a GKE
cluster) for a while now. There were no noticable differences in regards
to nested containers. We now decided to remove the pipeline from wings
and just keep the one on hush-house.

@BenTheElder 