### PR TITLE
Add example of a Github workflow using Kind

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -1,0 +1,23 @@
+name: Kind
+on: [push, pull_request]
+jobs:
+  test-unit:
+    name: Create a Kind cluster
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Install latest version of Kind
+      run: |
+        GO111MODULE=on go get sigs.k8s.io/kind
+    - name: Create Kind cluster
+      run: |
+        PATH=$(go env GOPATH)/bin:$PATH kind create cluster --config kind-config.yaml
+    - name: Run some sanity checks
+      # kubectl is already installed on the Github Ubuntu worker
+      run: |
+        kubectl get nodes -o wide
+        kubectl get pods --all-namespaces -o wide
+        kubectl get services --all-namespaces -o wide

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please file Pull Requests and / or Issues for missing CI platforms :smile:
 | [Travis CI](https://travis-ci.com/) | [Yes](.travis.yml) :heavy_check_mark: | [![Travis CI](https://travis-ci.com/kind-ci/examples.svg?branch=master)](https://travis-ci.com/kind-ci/examples/) |
 | [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) | [Yes](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kind) :heavy_check_mark: | [![Prow](https://prow.k8s.io/badge.svg?jobs=ci-kind-build)](https://prow.k8s.io/?job=ci-kind-build) |
 | [Concourse](https://concourse-ci.org/) | [Yes](concourse.md) :heavy_check_mark: | [![Concourse k8s](https://hush-house.pivotal.io/api/v1/teams/k8s-c10s/pipelines/kind/badge)](https://hush-house.pivotal.io/teams/k8s-c10s/pipelines/kind?group=all) |
+| [Github](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-continuous-integration) | [Yes](.github/workflows/kind.yml) :heavy_check_mark: | ![Github](https://github.com/kind-ci/examples/workflows/Kind/badge.svg) |
 | [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | [Yes](azure-pipelines.yml) :heavy_check_mark: | None |
 | [Drone](https://drone.io/) | [Yes](./drone) :heavy_check_mark: | None |
 | [Gitlab](https://about.gitlab.com/product/continuous-integration/) | [Yes](.gitlab-ci.yml) :heavy_check_mark: | None |


### PR DESCRIPTION
The project I work on - [Antrea](https://github.com/vmware-tanzu/antrea) - uses Kind for a Github CI workflow. I thought I would submit an example here.

Although the Github ubuntu worker comes with Kind pre-installed (https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners), it is version 0.5.1, and they may not update it very often. So the CI configuration file shows how to install the latest version of Kind.