### PR TITLE
Added Gitlab CI pipeline badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Please file Pull Requests and / or Issues for missing CI platforms :smile:
 | [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) | [Yes](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kind) :heavy_check_mark: | [![Prow](https://prow.k8s.io/badge.svg?jobs=ci-kind-build)](https://prow.k8s.io/?job=ci-kind-build) |
 | [Concourse](https://concourse-ci.org/) | [Yes](concourse.md) :heavy_check_mark: | [![Concourse k8s](https://hush-house.pivotal.io/api/v1/teams/k8s-c10s/pipelines/kind/badge)](https://hush-house.pivotal.io/teams/k8s-c10s/pipelines/kind?group=all) |
 | [Github](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-continuous-integration) | [Yes](.github/workflows/kind.yml) :heavy_check_mark: | ![Github](https://github.com/kind-ci/examples/workflows/Kind/badge.svg) |
+| [Gitlab](https://about.gitlab.com/product/continuous-integration/) | [Yes](.gitlab-ci.yml) :heavy_check_mark: | ![Gitlab](https://gitlab.com/kind-ci/examples/badges/master/pipeline.svg) |
 | [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | [Yes](azure-pipelines.yml) :heavy_check_mark: | None |
 | [Drone](https://drone.io/) | [Yes](./drone) :heavy_check_mark: | None |
-| [Gitlab](https://about.gitlab.com/product/continuous-integration/) | [Yes](.gitlab-ci.yml) :heavy_check_mark: | None |
 | [Google Cloud Build](https://cloud.google.com/cloud-build/) | [Yes](./gcb.md) :heavy_check_mark: | None |
 | [BuildKite](https://buildkite.com/) | Unsure :question: | None |
 | [CodeShip](https://codeship.com/) | Unsure :question: | None |


### PR DESCRIPTION
Updated readme to include gitlab pipeline badge for repo mirrored at https://gitlab.com/kind-ci/examples

I believe this closes https://github.com/kind-ci/examples/issues/12