### PR TITLE
Update GitLab CI example to kind v0.7.0.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: docker:stable
 variables:
-  KUBECTL: v1.15.0
-  KIND: v0.4.0
+  KUBECTL: v1.17.0
+  KIND: v0.7.0
 services:
   - docker:dind
 stages:
@@ -15,9 +15,7 @@ test:
     - wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL}/bin/linux/amd64/kubectl
     - chmod +x /usr/local/bin/kubectl
     - kind create cluster --config=./gitlab/kind-config.yaml
-    - sed -i -E -e 's/localhost|0\.0\.0\.0/docker/g' "$(kind get kubeconfig-path --name="kind")"
-    - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-    - kind get kubeconfig-path --name="kind"
+    - sed -i -E -e 's/localhost|0\.0\.0\.0/docker/g' "$HOME/.kube/config"
     - kubectl get nodes -o wide
     - kubectl get pods --all-namespaces -o wide
     - kubectl get services --all-namespaces -o wide

--- a/gitlab/kind-config.yaml
+++ b/gitlab/kind-config.yaml
@@ -1,10 +1,10 @@
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 networking:
   apiServerAddress: "0.0.0.0"
 
 # add to the apiServer certSANs the name of the docker (dind) service in order to be able to reach the cluster through it
-kubeadmConfigPatchesJson6902:
+kubeadmConfigPatchesJSON6902:
   - group: kubeadm.k8s.io
     version: v1beta2
     kind: ClusterConfiguration


### PR DESCRIPTION
Changes in recent releases to kind have removed the `kind get kubeconfig-path` functionality used in the current GitLab example.

This commit updates to the latest kind (v0.7.0) and adjusts the kind-config.yaml and .gitlab-ci.yml files to match.