### PR TITLE
Refresh the DroneCI example with a newer Kind version (0.11.0)

### DIFF
--- a/drone/.drone.yml
+++ b/drone/.drone.yml
@@ -18,7 +18,6 @@ steps:
     commands:
       - ./drone/install.sh
       - ./drone/setup.sh
-      - cp "$(kind get kubeconfig-path --name="$CLUSTER_NAME")" /mnt/config/admin.conf
       - kubectl get nodes
     volumes:
       - name: dockersock
@@ -30,7 +29,7 @@ steps:
       - push
 
   - name: test
-    image: alpine:3.9
+    image: alpine:3.14
     pull: always
     depends_on: [ setup ]
     environment:

--- a/drone/install.sh
+++ b/drone/install.sh
@@ -5,10 +5,10 @@ set -o nounset;
 # debug commands
 set -x;
 
-KUBECTL=v1.15.0
-KIND=v0.4.0
+KUBECTL=v1.21.0
+KIND=v0.11.0
 
-install(){  
+install(){
   wget -O /usr/local/bin/$1 $2
   chmod +x /usr/local/bin/$1
 }

--- a/drone/kind-config
+++ b/drone/kind-config
@@ -1,17 +1,16 @@
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+name: test
 networking:
   apiServerAddress: "0.0.0.0"
 
-# add to the apiServer certSANs the name of the drone service in order to be able to reach the cluster through it
-kubeadmConfigPatchesJson6902:
-- group: kubeadm.k8s.io
-  version: v1beta2
-  kind: ClusterConfiguration
-  patch: |
-    - op: add
-      path: /apiServer/certSANs/-
-      value: docker
 nodes:
+# add to the apiServer certSANs the name of the drone service in order to be able to reach the cluster through it
 - role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      certSANs:
+      - "docker"
 - role: worker

--- a/drone/setup.sh
+++ b/drone/setup.sh
@@ -9,5 +9,6 @@ set -x;
 kind create cluster --name "$CLUSTER_NAME" --config drone/kind-config --wait 1m
 
 #replace localhost or 0.0.0.0 in the kubeconfig file with "docker", in order to be able to reach the cluster through the docker service
-sed -i -E -e 's/localhost|0\.0\.0\.0/'"$CLUSTER_HOST"'/g' "$(kind get kubeconfig-path --name="$CLUSTER_NAME")"
+sed -i -E -e 's/localhost|0\.0\.0\.0/'"$CLUSTER_HOST"'/g' ${KUBECONFIG}
 
+kubectl wait node --all --for condition=ready


### PR DESCRIPTION
- The `alpine` version bump was just an upgrade to have `curl -o` to install Helm on a later stage. Older busybox-based images didn't support that flag. Not really needed for the example but nice to have.
- The result of running it can be seen on [this pipeline](https://drone.cernbox.cern.ch/SamuAlfageme/EOSaaS-drone-tests/12/) on our Drone instance.