### PR TITLE
fix(gitlab-ci): update kind/kubectl, alias dind service to kubernetes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,10 @@
 image: docker:stable
 variables:
-  KUBECTL: v1.17.0
-  KIND: v0.8.1
+  KUBECTL: v1.25.1
+  KIND: v0.15.0
 services:
-  - docker:dind
+  - name: docker:dind
+    alias: kubernetes
 stages:
   - test
 test:
@@ -15,7 +16,7 @@ test:
     - wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL}/bin/linux/amd64/kubectl
     - chmod +x /usr/local/bin/kubectl
     - kind create cluster --config=./gitlab/kind-config.yaml
-    - sed -i -E -e 's/localhost|0\.0\.0\.0/docker/g' "$HOME/.kube/config"
+    - sed -i -E -e 's/localhost|0\.0\.0\.0/kubernetes/g' "$HOME/.kube/config"
     - kubectl get nodes -o wide
     - kubectl get pods --all-namespaces -o wide
     - kubectl get services --all-namespaces -o wide

--- a/gitlab/kind-config.yaml
+++ b/gitlab/kind-config.yaml
@@ -3,15 +3,6 @@ kind: Cluster
 networking:
   apiServerAddress: "0.0.0.0"
 
-# add to the apiServer certSANs the name of the docker (dind) service in order to be able to reach the cluster through it
-kubeadmConfigPatchesJSON6902:
-  - group: kubeadm.k8s.io
-    version: v1beta2
-    kind: ClusterConfiguration
-    patch: |
-      - op: add
-        path: /apiServer/certSANs/-
-        value: docker
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
The previous example of gitlab-ci stopped working for us, for reasons I can no longer remember. However, we fixed our pipelines by aliasing the dind service to `kubernetes`, and this hostname is apparently present in the k8s certificate.

Also updated kubectl and kind.