### PR TITLE
Github action: Update several versions

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: 1.16
     - name: Install latest version of Kind
       run: |
         GO111MODULE=on go get sigs.k8s.io/kind


### PR DESCRIPTION
* Bumped the go action version to avoid a Github JS version warning, per  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

* Bumped the Go lang version to avoid an `cannot load io/fs` error, per https://github.com/hashicorp/packer/issues/10740