### PR TITLE
codebuild.md: known working codebuild example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ Please file Pull Requests and / or Issues for missing CI platforms :smile:
 | [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | [Yes](azure-pipelines.yml) :heavy_check_mark: | ![Azure Pipelines](https://dev.azure.com/kind-ci/examples/_apis/build/status/examples?api-version=5.1-preview.1) |
 | [Drone](https://drone.io/) | [Yes](./drone) :heavy_check_mark: | None |
 | [Google Cloud Build](https://cloud.google.com/cloud-build/) | [Yes](./gcb.md) :heavy_check_mark: | None |
+| [AWS Codebuild](https://aws.amazon.com/codebuild/) | [Yes](./codebuild.md) :heavy_check_mark: | None |
 | [BuildKite](https://buildkite.com/) | Unsure :question: | None |
 | [CodeShip](https://codeship.com/) | Unsure :question: | None |

--- a/codebuild.md
+++ b/codebuild.md
@@ -1,0 +1,26 @@
+# `kind` on AWS Codebuild
+
+Below is an example buildspec that works with codebuild image `aws/codebuild/standard5.0` (Ubuntu Standard 5). The Amazon Linux 2 images [do not seem to work][https://github.com/kubernetes-sigs/kind/issues/1383]
+
+## Example buildspec
+
+```buildspec.yml
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+        golang: 1.16
+  build:
+    commands:
+      - export GO111MODULE=on
+      - export PATH=$PATH:$(go env GOPATH)/bin
+      - go install sigs.k8s.io/kind@v0.17.0
+      - kind create cluster --wait 5m --config kind-config.yaml 
+      # TODO: find a better way poll things work
+      - sleep 300
+```
+
+## Notes
+
+- About 1-2% of the time, KIND fails to start. The failure happens immediately; it looks like it's related to some race condition between codebuild setting up it's docker plane and KIND attempting to use docker. Always on a restart KIND (and the build) succeeds.


### PR DESCRIPTION
Pretty straightforward buildspec. But it does seem like the default images (Amazon Linux 2) does not work with KIND.